### PR TITLE
fix: restrict abort operation on pending and in-progress

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -491,6 +491,12 @@ paths:
                 $ref: '#/components/schemas/defaultOkMessage'
               example:
                 code: JOB_ABORTED_SUCCESSFULLY
+        '400':
+          description: Illegal abort request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorMessage'
         '404':
           description: job not found
           content:

--- a/src/taskManagement/models/taskManagementManger.ts
+++ b/src/taskManagement/models/taskManagementManger.ts
@@ -54,12 +54,12 @@ export class TaskManagementManager {
     const jobRepo = await this.getJobRepository();
     const jobEntity = await jobRepo.getJob(req.jobId, false);
     if (!jobEntity) {
-      const message = 'job was not found for provided update request';
+      const message = 'Job abort request failed, job was not found for provided update request';
       this.logger.error({ jobId: req.jobId, msg: message });
       throw new NotFoundError(message);
     }
     if ((jobEntity.status as OperationStatus) !== OperationStatus.PENDING && (jobEntity.status as OperationStatus) !== OperationStatus.IN_PROGRESS) {
-      const message = 'job status should be one of: "Pending" or "In-progress"';
+      const message = 'Job abort request failed, job status should be one of: "Pending" or "In-progress"';
       this.logger.error({ jobStatus: jobEntity.status, msg: message });
       throw new BadRequestError(message);
     }

--- a/src/taskManagement/models/taskManagementManger.ts
+++ b/src/taskManagement/models/taskManagementManger.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@map-colonies/js-logger';
-import { NotFoundError } from '@map-colonies/error-types';
+import { NotFoundError, BadRequestError } from '@map-colonies/error-types';
 import { inject, injectable } from 'tsyringe';
 import { SERVICES } from '../../common/constants';
 import { ConnectionManager } from '../../DAL/connectionManager';
@@ -52,6 +52,17 @@ export class TaskManagementManager {
 
   public async abortJobAndTasks(req: IJobsParams): Promise<void> {
     const jobRepo = await this.getJobRepository();
+    const jobEntity = await jobRepo.getJob(req.jobId, false);
+    if (!jobEntity) {
+      const message = 'job was not found for provided update request';
+      this.logger.error({ jobId: req.jobId, msg: message });
+      throw new NotFoundError(message);
+    }
+    if ((jobEntity.status as OperationStatus) !== OperationStatus.PENDING && (jobEntity.status as OperationStatus) !== OperationStatus.IN_PROGRESS) {
+      const message = 'job status should be one of: "Pending" or "In-progress"';
+      this.logger.error({ jobStatus: jobEntity.status, msg: message });
+      throw new BadRequestError(message);
+    }
     await jobRepo.updateJob({ jobId: req.jobId, status: OperationStatus.ABORTED });
     const taskRepo = await this.getTaskRepository();
     await taskRepo.abortJobTasks(req.jobId);

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -33,7 +33,7 @@ module.exports = {
       branches: 0,
       functions: 10,
       lines: 15,
-      statements: 17,
+      statements: 15,
     },
   },
 };


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                       |
| Chore            | ✖                                                                       |

Fix and restrict the abort API so it will be able only for in-progress and pending status jobs