### PR TITLE
fix: provide types and ignoreTypes array for inactive API (MAPCO-3022)

### DIFF
--- a/src/DAL/repositories/jobRepository.ts
+++ b/src/DAL/repositories/jobRepository.ts
@@ -109,10 +109,10 @@ export class JobRepository extends GeneralRepository<JobEntity> {
 
   public async getJob(id: string, query: IJobsQuery): Promise<IGetJobResponse | undefined> {
     let entity;
-    if (!query.shouldReturnTasks) {
-      entity = await this.findOne(id);
-    } else {
+    if (query.shouldReturnTasks === true) {
       entity = await this.findOne(id, { relations: ['tasks'] });
+    } else {
+      entity = await this.findOne(id);
     }
 
     const model = entity ? this.jobConvertor.entityToModel(entity) : undefined;

--- a/src/DAL/repositories/taskRepository.ts
+++ b/src/DAL/repositories/taskRepository.ts
@@ -170,7 +170,6 @@ export class TaskRepository extends GeneralRepository<TaskEntity> {
     const hasTypes = req.types != undefined && req.types.length > 0;
     const hasIgnoredTypes = req.ignoreTypes != undefined && req.ignoreTypes.length > 0;
     if (hasTypes || hasIgnoredTypes) {
-      // query = query.innerJoin('tk.jobId', 'jb');
       query = query.innerJoin(JobEntity, 'jb', 'jb.id = tk.jobId');
       if (hasTypes) {
         const types = req.types as ITaskType[];


### PR DESCRIPTION
Bug Fix

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                       |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

Fix the logic of "getInActiveApi":
1. the innerJoin between job and task according jobId.
2. fix the logic of query building to find all types and ingoreTypes (bug on by reference)