### PR TITLE
chore: change job "isAbortable" condition(MAPCO-3021)

### DIFF
--- a/src/DAL/repositories/jobRepository.ts
+++ b/src/DAL/repositories/jobRepository.ts
@@ -188,4 +188,14 @@ export class JobRepository extends GeneralRepository<JobEntity> {
     const res = sqlRes[0];
     return parseInt(res.unResettableTasks) === 0 && parseInt(res.failedTasks) > 0;
   }
+
+  public async isJobHasPendingTasks(jobId: string): Promise<boolean> {
+    const pendingTasksCount = await this.createQueryBuilder('job')
+      .leftJoinAndSelect('job.tasks', 'task')
+      .where('job.id = :jobId', { jobId })
+      .andWhere('task.status = :status', { status: OperationStatus.PENDING })
+      .getCount();
+
+    return pendingTasksCount > 0;
+  }
 }

--- a/src/jobs/models/jobManager.ts
+++ b/src/jobs/models/jobManager.ts
@@ -98,11 +98,19 @@ export class JobManager {
 
   private async getAvailableActions(job: IGetJobResponse): Promise<IAvailableActions> {
     const isResettable = (await this.isResettable({ jobId: job.id })).isResettable;
+    const isAbortable = await this.isAbortable(job);
     const availableActions: IAvailableActions = {
       isResumable: isResettable,
-      isAbortable: job.status === OperationStatus.PENDING || job.status === OperationStatus.IN_PROGRESS,
+      isAbortable: isAbortable,
     };
     return availableActions;
+  }
+
+  private async isAbortable(job: IGetJobResponse): Promise<boolean> {
+    const jobId = job.id;
+    const repo = await this.getRepository();
+    const hasPendingTasks = await repo.isJobHasPendingTasks(jobId);
+    return hasPendingTasks && (job.status === OperationStatus.PENDING || job.status === OperationStatus.IN_PROGRESS);
   }
 
   private async getRepository(): Promise<JobRepository> {

--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -71,7 +71,7 @@ function createJobDataForFind(): unknown {
     productType: 'productType',
     additionalIdentifiers: '',
     availableActions: {
-      isAbortable: true,
+      isAbortable: false,
       isResumable: false,
     },
   };
@@ -128,7 +128,7 @@ function createJobDataForGetJob(): unknown {
     productType: 'productType',
     additionalIdentifiers: '',
     availableActions: {
-      isAbortable: true,
+      isAbortable: false,
       isResumable: false,
     },
   };
@@ -313,7 +313,7 @@ describe('job', function () {
         const findJobsSpy = jest.spyOn(JobManager.prototype, 'findJobs');
         jobsFindMock.mockResolvedValue([jobEntity]);
         const expectedAvailableActions: IAvailableActions = {
-          isAbortable: true,
+          isAbortable: false,
           isResumable: false,
         };
 
@@ -520,7 +520,7 @@ describe('job', function () {
         delete jobEntity.tasks;
         jobsFindOneMock.mockResolvedValue(jobEntity);
         const expectedAvailableActions: IAvailableActions = {
-          isAbortable: true,
+          isAbortable: false,
           isResumable: false,
         };
 

--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -71,7 +71,7 @@ function createJobDataForFind(): unknown {
     productType: 'productType',
     additionalIdentifiers: '',
     availableActions: {
-      isAbortable: false,
+      isAbortable: true,
       isResumable: false,
     },
   };
@@ -128,7 +128,7 @@ function createJobDataForGetJob(): unknown {
     productType: 'productType',
     additionalIdentifiers: '',
     availableActions: {
-      isAbortable: false,
+      isAbortable: true,
       isResumable: false,
     },
   };
@@ -136,6 +136,124 @@ function createJobDataForGetJob(): unknown {
   return jobModel;
 }
 
+function isJobHasPendingTasksMock(tasks: TaskEntity[] | undefined): boolean {
+  if (tasks === undefined) {
+    return false;
+  }
+  return tasks.some((task) => task.status === OperationStatus.PENDING);
+}
+
+function createJobDataForAvailableActionsWithoutAbortableJob(): unknown {
+  const taskModel = {
+    jobId: '170dd8c0-8bad-498b-bb26-671dcf19aa3c',
+    id: 'taskId',
+    description: '1',
+    parameters: {
+      a: 2,
+    },
+    reason: '3',
+    percentage: 4,
+    type: '5',
+    status: OperationStatus.IN_PROGRESS,
+    created: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    updated: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    attempts: 0,
+    resettable: true,
+  };
+  const jobModel = {
+    id: '170dd8c0-8bad-498b-bb26-671dcf19aa3c',
+    resourceId: '11',
+    version: '12',
+    description: '13',
+    domain: '',
+    parameters: {
+      d: 14,
+    },
+    status: OperationStatus.PENDING,
+    reason: '15',
+    type: '16',
+    percentage: 17,
+    tasks: [taskModel],
+    created: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    updated: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    isCleaned: false,
+    taskCount: 0,
+    completedTasks: 0,
+    failedTasks: 0,
+    expiredTasks: 0,
+    pendingTasks: 0,
+    inProgressTasks: 0,
+    abortedTasks: 0,
+    priority: 1000,
+    expirationDate: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    internalId: '170dd8c0-8bad-498b-bb26-671dcf19aa3c',
+    producerName: 'producerName',
+    productName: 'productName',
+    productType: 'productType',
+    additionalIdentifiers: '',
+    availableActions: {
+      isAbortable: false,
+      isResumable: false,
+    },
+  };
+  return jobModel;
+}
+
+function createJobDataForAvailableActionsWithAbortableJob(): unknown {
+  const taskModel = {
+    jobId: '170dd8c0-8bad-498b-bb26-671dcf19aa3c',
+    id: 'taskId',
+    description: '1',
+    parameters: {
+      a: 2,
+    },
+    reason: '3',
+    percentage: 4,
+    type: '5',
+    status: OperationStatus.PENDING,
+    created: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    updated: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    attempts: 0,
+    resettable: true,
+  };
+  const jobModel = {
+    id: '170dd8c0-8bad-498b-bb26-671dcf19aa3c',
+    resourceId: '11',
+    version: '12',
+    description: '13',
+    domain: '',
+    parameters: {
+      d: 14,
+    },
+    status: OperationStatus.PENDING,
+    reason: '15',
+    type: '16',
+    percentage: 17,
+    tasks: [taskModel],
+    created: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    updated: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    isCleaned: false,
+    taskCount: 0,
+    completedTasks: 0,
+    failedTasks: 0,
+    expiredTasks: 0,
+    pendingTasks: 0,
+    inProgressTasks: 0,
+    abortedTasks: 0,
+    priority: 1000,
+    expirationDate: new Date(Date.UTC(2000, 1, 2)).toISOString(),
+    internalId: '170dd8c0-8bad-498b-bb26-671dcf19aa3c',
+    producerName: 'producerName',
+    productName: 'productName',
+    productType: 'productType',
+    additionalIdentifiers: '',
+    availableActions: {
+      isAbortable: true,
+      isResumable: false,
+    },
+  };
+  return jobModel;
+}
 function jobModelToEntity(jobModel: unknown): JobEntity {
   const model = jobModel as {
     created: string;
@@ -309,11 +427,13 @@ describe('job', function () {
         const jobModel = createJobDataForFind();
         const jobEntity = jobModelToEntity(jobModel);
         const jobsFindMock = jobRepositoryMocks.findMock;
+        const isJobHasPendingTasksSpy = jest.spyOn(JobRepository.prototype, 'isJobHasPendingTasks');
+        isJobHasPendingTasksSpy.mockResolvedValue(true);
         jobRepositoryMocks.queryMock.mockResolvedValue([{ unResettableTasks: '1', failedTasks: '3' }]);
         const findJobsSpy = jest.spyOn(JobManager.prototype, 'findJobs');
         jobsFindMock.mockResolvedValue([jobEntity]);
         const expectedAvailableActions: IAvailableActions = {
-          isAbortable: false,
+          isAbortable: true,
           isResumable: false,
         };
 
@@ -517,6 +637,80 @@ describe('job', function () {
         const jobsFindOneMock = jobRepositoryMocks.findOneMock;
         jobRepositoryMocks.queryMock.mockResolvedValue([{ unResettableTasks: '1', failedTasks: '3' }]);
         const getJobSpy = jest.spyOn(JobManager.prototype, 'getJob');
+        delete jobEntity.tasks;
+        jobsFindOneMock.mockResolvedValue(jobEntity);
+        const isJobHasPendingTasksSpy = jest.spyOn(JobRepository.prototype, 'isJobHasPendingTasks');
+        isJobHasPendingTasksSpy.mockResolvedValue(true);
+        const expectedAvailableActions: IAvailableActions = {
+          isAbortable: true,
+          isResumable: false,
+        };
+
+        const response = await requestSender.getResource('170dd8c0-8bad-498b-bb26-671dcf19aa3c', false, true);
+
+        expect(response.status).toBe(httpStatusCodes.OK);
+        expect(jobsFindOneMock).toHaveBeenCalledTimes(1);
+        expect(jobsFindOneMock).toHaveBeenCalledWith('170dd8c0-8bad-498b-bb26-671dcf19aa3c');
+
+        const job = response.body as IGetJobResponse;
+
+        delete (jobModel as JobEntity).tasks;
+        expect(job).toEqual(jobModel);
+        expect(getJobSpy).toHaveBeenCalledWith(
+          { jobId: '170dd8c0-8bad-498b-bb26-671dcf19aa3c' },
+          { shouldReturnTasks: false, shouldReturnAvailableActions: true }
+        );
+        expect(Object.keys(job)).toContain('availableActions');
+        expect(job.availableActions).toEqual(expectedAvailableActions);
+        expect(response).toSatisfyApiSpec();
+        getJobSpy.mockRestore();
+      });
+
+      it('should get specific job and return 200 with the available actions and true for isAbortable', async function () {
+        const jobModel = createJobDataForAvailableActionsWithAbortableJob();
+        const jobEntity = jobModelToEntity(jobModel);
+        const jobsFindOneMock = jobRepositoryMocks.findOneMock;
+        jobRepositoryMocks.queryMock.mockResolvedValue([{ unResettableTasks: '1', failedTasks: '3' }]);
+        const getJobSpy = jest.spyOn(JobManager.prototype, 'getJob');
+        const isJobHasPendingTasksSpy = jest.spyOn(JobRepository.prototype, 'isJobHasPendingTasks');
+        const condition = isJobHasPendingTasksMock(jobEntity.tasks);
+        isJobHasPendingTasksSpy.mockResolvedValue(condition);
+        delete jobEntity.tasks;
+        jobsFindOneMock.mockResolvedValue(jobEntity);
+        const expectedAvailableActions: IAvailableActions = {
+          isAbortable: true,
+          isResumable: false,
+        };
+
+        const response = await requestSender.getResource('170dd8c0-8bad-498b-bb26-671dcf19aa3c', false, true);
+
+        expect(response.status).toBe(httpStatusCodes.OK);
+        expect(jobsFindOneMock).toHaveBeenCalledTimes(1);
+        expect(jobsFindOneMock).toHaveBeenCalledWith('170dd8c0-8bad-498b-bb26-671dcf19aa3c');
+
+        const job = response.body as IGetJobResponse;
+
+        delete (jobModel as JobEntity).tasks;
+        expect(job).toEqual(jobModel);
+        expect(getJobSpy).toHaveBeenCalledWith(
+          { jobId: '170dd8c0-8bad-498b-bb26-671dcf19aa3c' },
+          { shouldReturnTasks: false, shouldReturnAvailableActions: true }
+        );
+        expect(Object.keys(job)).toContain('availableActions');
+        expect(job.availableActions).toEqual(expectedAvailableActions);
+        expect(response).toSatisfyApiSpec();
+        getJobSpy.mockRestore();
+      });
+
+      it('should get specific job and return 200 with the available actions and false for isAbortable', async function () {
+        const jobModel = createJobDataForAvailableActionsWithoutAbortableJob();
+        const jobEntity = jobModelToEntity(jobModel);
+        const jobsFindOneMock = jobRepositoryMocks.findOneMock;
+        jobRepositoryMocks.queryMock.mockResolvedValue([{ unResettableTasks: '1', failedTasks: '3' }]);
+        const getJobSpy = jest.spyOn(JobManager.prototype, 'getJob');
+        const isJobHasPendingTasksSpy = jest.spyOn(JobRepository.prototype, 'isJobHasPendingTasks');
+        const condition = isJobHasPendingTasksMock(jobEntity.tasks);
+        isJobHasPendingTasksSpy.mockResolvedValue(condition);
         delete jobEntity.tasks;
         jobsFindOneMock.mockResolvedValue(jobEntity);
         const expectedAvailableActions: IAvailableActions = {

--- a/tests/mocks/DBMock.ts
+++ b/tests/mocks/DBMock.ts
@@ -58,6 +58,8 @@ interface QueryBuilder {
   returning: jest.Mock;
   updateEntity: jest.Mock;
   execute: jest.Mock;
+  leftJoinAndSelect: jest.Mock;
+  getCount: jest.Mock;
 }
 
 interface RepositoryMocks {
@@ -91,6 +93,8 @@ const registerRepository = <T>(key: ObjectType<T>, instance: T): RepositoryMocks
       returning: jest.fn(),
       updateEntity: jest.fn(),
       execute: jest.fn(),
+      leftJoinAndSelect: jest.fn(),
+      getCount: jest.fn(),
     },
     queryMock: jest.fn(),
     updateMock: jest.fn(),
@@ -113,6 +117,8 @@ const registerRepository = <T>(key: ObjectType<T>, instance: T): RepositoryMocks
   mocks.queryBuilder.set.mockImplementation(() => mocks.queryBuilder);
   mocks.queryBuilder.returning.mockImplementation(() => mocks.queryBuilder);
   mocks.queryBuilder.updateEntity.mockImplementation(() => mocks.queryBuilder);
+  mocks.queryBuilder.leftJoinAndSelect.mockImplementation(() => mocks.queryBuilder);
+  mocks.queryBuilder.getCount.mockImplementation(() => mocks.queryBuilder);
 
   repositories[key.name] = repo;
   return mocks;


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Further  information:
The isAbortable condition for the job has changed to the following: The job's OperationStatus should be Pending or InProgress (as it was) **and in addition**, the job needs to have at least one pending task to be aborted.