### PR TITLE
fix: release-tasks-according-to-job-status (MAPCO-3951)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@map-colonies/openapi-express-viewer": "^3.0.0",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "4.1.0",
+        "@ngneat/falso": "^7.1.1",
         "@opentelemetry/api": "1.4.0",
         "@opentelemetry/api-metrics": "0.24.0",
         "@opentelemetry/instrumentation-express": "0.32.1",
@@ -3478,6 +3479,15 @@
       "integrity": "sha512-7lmGpLL/7EHQcLVBxxOesgQQS7JSxzF/Xqx7VNMxAQbo14dzJEX6Ks0hb4LHqEMpCrKpErWXi4JxYCGrRJgx9A==",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/@ngneat/falso": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@ngneat/falso/-/falso-7.1.1.tgz",
+      "integrity": "sha512-/5HuJDaZHXl3WVdgvYBAM52OSYbSKfiNazVOZOw/3KjeZ6dQW9F0QCG+W6z52lUu5MZvp/TkPGaVRtoz6h9T1w==",
+      "dependencies": {
+        "seedrandom": "3.0.5",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -16003,6 +16013,11 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
       "version": "7.5.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@map-colonies/openapi-express-viewer": "^3.0.0",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "4.1.0",
+    "@ngneat/falso": "^7.1.1",
     "@opentelemetry/api": "1.4.0",
     "@opentelemetry/api-metrics": "0.24.0",
     "@opentelemetry/instrumentation-express": "0.32.1",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,5 +1,6 @@
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { ResponseCodes } from './constants';
+import { OperationStatus } from './dataModels/enums';
 
 export interface IConfig {
   get: <T>(setting: string) => T;
@@ -24,4 +25,11 @@ export interface IHttpResponse<T> {
 
 export interface DefaultResponse {
   code: ResponseCodes;
+}
+
+export interface IJobAndTaskStatus {
+  taskId: string;
+  jobId: string;
+  taskStatus: OperationStatus;
+  jobStatus: OperationStatus;
 }

--- a/tests/mocks/values.ts
+++ b/tests/mocks/values.ts
@@ -1,5 +1,21 @@
 import { randUuid } from '@ngneat/falso';
+import { IJobAndTaskStatus } from '../../src/common/interfaces';
+import { OperationStatus } from '../../src/common/dataModels/enums';
 
 export const createUuid = (): string => {
   return randUuid();
+};
+
+export const createJobAndTaskStatus = (
+  jobStatus: OperationStatus,
+  taskId = createUuid(),
+  jobId = createUuid(),
+  taskStatus = OperationStatus.IN_PROGRESS
+): IJobAndTaskStatus => {
+  return {
+    taskId,
+    taskStatus,
+    jobId,
+    jobStatus,
+  };
 };

--- a/tests/mocks/values.ts
+++ b/tests/mocks/values.ts
@@ -1,0 +1,5 @@
+import { randUuid } from '@ngneat/falso';
+
+export const createUuid = (): string => {
+  return randUuid();
+};


### PR DESCRIPTION
When changing the status of inactive task, we need to change it according to job status.
This PR fixes it

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |