### PR TITLE
fix: add default not value empty string to "additionalIdentifiers" (MAPCO-4357)

### DIFF
--- a/src/DAL/migration/FullSchema.sql
+++ b/src/DAL/migration/FullSchema.sql
@@ -35,7 +35,7 @@ CREATE TABLE "Job"
   "pendingTasks" int NOT NULL DEFAULT 0,
   "inProgressTasks" int NOT NULL DEFAULT 0,
   "abortedTasks" int NOT NULL DEFAULT 0,
-  "additionalIdentifiers" text COLLATE pg_catalog."default",
+  "additionalIdentifiers" text COLLATE pg_catalog."default" NOT NULL DEFAULT ''::text,
   "domain" text COLLATE pg_catalog."default" NOT NULL DEFAULT ''::text,
   CONSTRAINT "PK_job_id" PRIMARY KEY (id),
   CONSTRAINT "UQ_uniqueness_on_active_tasks" EXCLUDE ("resourceId" with =, "version" with =, "type" with =, "additionalIdentifiers" with =) WHERE (status = 'Pending' OR status = 'In-Progress')

--- a/src/DAL/migration/v.2.6.1.sql
+++ b/src/DAL/migration/v.2.6.1.sql
@@ -1,0 +1,11 @@
+-- v2.6.1 db migration script --
+SET search_path TO "JobManager", public; -- CHANGE SCHEMA NAME TO MATCH ENVIRONMENT
+
+ALTER TABLE "Job"
+ALTER COLUMN "additionalIdentifiers" SET DEFAULT ''::text;
+
+UPDATE "Job"
+SET "additionalIdentifiers" = COALESCE("additionalIdentifiers", '');
+
+ALTER TABLE "Job"
+ALTER COLUMN "additionalIdentifiers" SET NOT NULL;


### PR DESCRIPTION
additionalIdentifiers column is one of the constrain columns of uniquness.

on case that user not provide it, it act as null and than not affect on constrains -> it lead to duplications bug.

we added new migration and full schema update -> if not provided so it will be empty string


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

