### PR TITLE
fix: adapting new CI workflow version

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -19,9 +19,9 @@ permissions:
 
 jobs:
   build_and_push_docker:
-      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@master
+      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v1
       secrets: inherit
   
   build_and_push_helm:
-      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@master
+      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v1
       secrets: inherit

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,5 +4,5 @@ on: [pull_request]
 
 jobs:
   pull_request:
-    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@master
+    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@v1
     secrets: inherit

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release_on_tag_push:
-    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@master
+    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@v1
     secrets: inherit


### PR DESCRIPTION
use v1 instead of master on CI's workflows

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
