### PR TITLE
feat: enable search with multiple types and statuses (MAPCO-4427, MAPCO-4430)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -70,6 +70,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/errorMessage'
+  /jobs/find:
+    post:
+      operationId: findJobsByCriteria
+      summary: gets jobs by criteria
+      tags:
+        - jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/getJobsByCriteria'
+      responses:
+        '200':
+          description: Array of jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/jobResponse'
   /jobs/{jobId}:
     parameters:
       - $ref: '#/components/parameters/jobId'
@@ -668,6 +689,43 @@ components:
         type: string
         format: uuid
   schemas:
+    getJobsByCriteria:
+      type: object
+      description: get jobs criteria
+      properties:
+        resourceId:
+          type: string
+        version:
+          type: string
+        isCleaned:
+          type: boolean
+        status:
+          type: array
+          items:
+            $ref: '#/components/schemas/status'
+        type:
+          type: array
+          items:
+            type: string
+        shouldReturnTasks:
+          type: boolean
+          default: false
+        fromDate:
+          type: string
+          format: date-time
+        tillDate:
+          type: string
+          format: date-time
+        productType:
+          type: string
+        internalId:
+          type: string
+          format: uuid
+        domain:
+          type: string
+        shouldReturnAvailableActions:
+          type: boolean
+          default: false
     findTaskRequest:
       type: object
       description: task find model

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -699,11 +699,11 @@ components:
           type: string
         isCleaned:
           type: boolean
-        status:
+        statuses:
           type: array
           items:
             $ref: '#/components/schemas/status'
-        type:
+        types:
           type: array
           items:
             type: string

--- a/src/DAL/repositories/jobRepository.ts
+++ b/src/DAL/repositories/jobRepository.ts
@@ -14,6 +14,7 @@ import {
   IFindJobsRequest,
   IUpdateJobRequest,
   IJobsQuery,
+  IFindJobsByCriteriaBody,
 } from '../../common/dataModels/jobs';
 import { JobModelConvertor } from '../convertors/jobModelConverter';
 import { OperationStatus } from '../../common/dataModels/enums';
@@ -65,6 +66,44 @@ export class JobRepository extends GeneralRepository<JobEntity> {
     }
 
     const entities = await this.find(options);
+    const models = entities.map((entity) => this.jobConvertor.entityToModel(entity));
+    return models;
+  }
+
+  public async findJobsByCriteria(req: IFindJobsByCriteriaBody): Promise<FindJobsResponse> {
+    const filter: Record<string, unknown> = {
+      resourceId: req.resourceId,
+      version: req.version,
+      isCleaned: req.isCleaned,
+      productType: req.productType,
+      internalId: req.internalId,
+      domain: req.domain,
+    };
+
+    if (req.fromDate != undefined && req.tillDate != undefined) {
+      filter.updateTime = Between(req.fromDate, req.tillDate);
+    } else if (req.tillDate != undefined) {
+      filter.updateTime = LessThanOrEqual(req.tillDate);
+    } else if (req.fromDate != undefined) {
+      filter.updateTime = MoreThanOrEqual(req.fromDate);
+    }
+
+    for (const key of Object.keys(filter)) {
+      if (filter[key] == undefined) {
+        delete filter[key];
+      }
+    }
+    if (req.shouldReturnTasks !== false) {
+      filter.relations = ['tasks'];
+    }
+    const queryBuilder = this.createQueryBuilder().select('job').from(JobEntity, 'job').where(filter);
+    if ((req.type?.length ?? 0) > 0) {
+      queryBuilder.andWhere('job.type IN (:...types)', { types: req.type });
+    }
+    if ((req.status?.length ?? 0) > 0) {
+      queryBuilder.andWhere('job.status IN (:...statuses)', { statuses: req.status });
+    }
+    const entities = await queryBuilder.getMany();
     const models = entities.map((entity) => this.jobConvertor.entityToModel(entity));
     return models;
   }

--- a/src/DAL/repositories/jobRepository.ts
+++ b/src/DAL/repositories/jobRepository.ts
@@ -97,11 +97,11 @@ export class JobRepository extends GeneralRepository<JobEntity> {
       filter.relations = ['tasks'];
     }
     const queryBuilder = this.createQueryBuilder().select('job').from(JobEntity, 'job').where(filter);
-    if ((req.type?.length ?? 0) > 0) {
-      queryBuilder.andWhere('job.type IN (:...types)', { types: req.type });
+    if ((req.types?.length ?? 0) > 0) {
+      queryBuilder.andWhere('job.type IN (:...types)', { types: req.types });
     }
-    if ((req.status?.length ?? 0) > 0) {
-      queryBuilder.andWhere('job.status IN (:...statuses)', { statuses: req.status });
+    if ((req.statuses?.length ?? 0) > 0) {
+      queryBuilder.andWhere('job.status IN (:...statuses)', { statuses: req.statuses });
     }
     const entities = await queryBuilder.getMany();
     const models = entities.map((entity) => this.jobConvertor.entityToModel(entity));

--- a/src/common/dataModels/jobs.ts
+++ b/src/common/dataModels/jobs.ts
@@ -30,8 +30,8 @@ export interface IFindJobsByCriteriaBody {
   resourceId?: string;
   version?: string;
   isCleaned?: boolean;
-  status?: OperationStatus[];
-  type?: string[];
+  statuses?: OperationStatus[];
+  types?: string[];
   shouldReturnTasks?: boolean;
   shouldReturnAvailableActions?: boolean;
   productType?: string;

--- a/src/common/dataModels/jobs.ts
+++ b/src/common/dataModels/jobs.ts
@@ -30,8 +30,8 @@ export interface IFindJobsByCriteriaBody {
   resourceId?: string;
   version?: string;
   isCleaned?: boolean;
-  status?: [OperationStatus];
-  type?: [string];
+  status?: OperationStatus[];
+  type?: string[];
   shouldReturnTasks?: boolean;
   shouldReturnAvailableActions?: boolean;
   productType?: string;

--- a/src/common/dataModels/jobs.ts
+++ b/src/common/dataModels/jobs.ts
@@ -26,6 +26,21 @@ export interface IFindJobsRequest {
   domain?: string;
 }
 
+export interface IFindJobsByCriteriaBody {
+  resourceId?: string;
+  version?: string;
+  isCleaned?: boolean;
+  status?: [OperationStatus];
+  type?: [string];
+  shouldReturnTasks?: boolean;
+  shouldReturnAvailableActions?: boolean;
+  productType?: string;
+  fromDate?: string;
+  tillDate?: string;
+  internalId?: string;
+  domain?: string;
+}
+
 export interface ICreateJobBody {
   resourceId: string;
   version: string;

--- a/src/jobs/controllers/jobController.ts
+++ b/src/jobs/controllers/jobController.ts
@@ -7,6 +7,7 @@ import {
   FindJobsResponse,
   ICreateJobBody,
   ICreateJobResponse,
+  IFindJobsByCriteriaBody,
   IFindJobsRequest,
   IGetJobResponse,
   IIsResettableResponse,
@@ -22,6 +23,7 @@ import { JobParameters } from '../../DAL/repositories/jobRepository';
 
 type CreateResourceHandler = RequestHandler<undefined, ICreateJobResponse, ICreateJobBody>;
 type FindResourceHandler = RequestHandler<undefined, FindJobsResponse, undefined, IFindJobsRequest>;
+type FindResourceByCriteriaHandler = RequestHandler<undefined, FindJobsResponse, IFindJobsByCriteriaBody>;
 type GetJobsByJobsParametersHandler = RequestHandler<undefined, FindJobsResponse, undefined, JobParameters>;
 type GetResourceHandler = RequestHandler<IJobsParams, IGetJobResponse, undefined, IJobsQuery>;
 type DeleteResourceHandler = RequestHandler<IJobsParams, DefaultResponse>;
@@ -44,6 +46,15 @@ export class JobController {
   public findResource: FindResourceHandler = async (req, res, next) => {
     try {
       const jobsRes = await this.manager.findJobs(req.query);
+      return res.status(httpStatus.OK).json(jobsRes);
+    } catch (err) {
+      return next(err);
+    }
+  };
+
+  public findResourceByCriteria: FindResourceByCriteriaHandler = async (req, res, next) => {
+    try {
+      const jobsRes = await this.manager.findJobsByCriteria(req.body);
       return res.status(httpStatus.OK).json(jobsRes);
     } catch (err) {
       return next(err);

--- a/src/jobs/models/jobManager.ts
+++ b/src/jobs/models/jobManager.ts
@@ -17,6 +17,7 @@ import {
   IIsResettableResponse,
   IResetJobRequest,
   IAvailableActions,
+  IFindJobsByCriteriaBody,
 } from '../../common/dataModels/jobs';
 import { JobParameters, JobRepository } from '../../DAL/repositories/jobRepository';
 import { TransactionActions } from '../../DAL/repositories/transactionActions';
@@ -37,6 +38,24 @@ export class JobManager {
     const repo = await this.getRepository();
 
     let res = await repo.findJobs(req);
+
+    if (req.shouldReturnAvailableActions === true) {
+      if (res.length !== 0) {
+        res = await Promise.all(
+          res.map(async (job) => ({
+            ...job,
+            availableActions: await this.getAvailableActions(job),
+          }))
+        );
+      }
+    }
+    return res;
+  }
+
+  @withSpanAsyncV4
+  public async findJobsByCriteria(req: IFindJobsByCriteriaBody): Promise<FindJobsResponse> {
+    const repo = await this.getRepository();
+    let res = await repo.findJobsByCriteria(req);
 
     if (req.shouldReturnAvailableActions === true) {
       if (res.length !== 0) {

--- a/src/jobs/routes/jobRouter.ts
+++ b/src/jobs/routes/jobRouter.ts
@@ -9,6 +9,7 @@ const jobRouterFactory: FactoryFunction<Router> = (dependencyContainer) => {
   const tasksController = dependencyContainer.resolve(TaskController);
 
   router.get('/', jobsController.findResource);
+  router.post('/find', jobsController.findResourceByCriteria);
   router.post('/', jobsController.createResource);
   router.get('/parameters', jobsController.getJobByJobsParameters);
   router.get('/:jobId', jobsController.getResource);

--- a/tests/configurations/integration/jest.config.js
+++ b/tests/configurations/integration/jest.config.js
@@ -1,11 +1,6 @@
 module.exports = {
   transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
-    },
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
   },
   coverageReporters: ['text', 'html'],
   collectCoverage: true,

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -1,11 +1,6 @@
 module.exports = {
   transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
-    },
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
   },
   testMatch: ['<rootDir>/tests/unit/**/*.spec.ts'],
   coverageReporters: ['text', 'html'],

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     '!**/controllers/**',
     '!**/routes/**',
     '!<rootDir>/src/*',
+    '!<rootDir>/src/DAL/*'
   ],
   coverageDirectory: '<rootDir>/coverage',
   reporters: [

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
     '!**/controllers/**',
     '!**/routes/**',
     '!<rootDir>/src/*',
-    '!<rootDir>/src/DAL/*'
+    '!<rootDir>/src/DAL/*',
   ],
   coverageDirectory: '<rootDir>/coverage',
   reporters: [

--- a/tests/integration/jobs/helpers/jobsRequestSender.ts
+++ b/tests/integration/jobs/helpers/jobsRequestSender.ts
@@ -41,6 +41,10 @@ export class JobsRequestSender {
     return supertest.agent(this.app).post(`/jobs`).set('Content-Type', 'application/json').send(body);
   }
 
+  public async findJobs(body: Record<string, unknown>): Promise<supertest.Response> {
+    return supertest.agent(this.app).post(`/jobs/find`).set('Content-Type', 'application/json').send(body);
+  }
+
   public async deleteResource(id: string): Promise<supertest.Response> {
     return supertest.agent(this.app).delete(`/jobs/${id}`).set('Content-Type', 'application/json');
   }

--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -621,7 +621,7 @@ describe('job', function () {
         expect(response).toSatisfyApiSpec();
       });
 
-      it('should no jobs and return 200', async function () {
+      it('should not find matched jobs and return status 200 with an empty array', async function () {
         const filter = {
           isCleaned: true,
           resourceId: '1',
@@ -645,6 +645,7 @@ describe('job', function () {
         expect(where).toHaveBeenCalledTimes(1);
         expect(andWhere).toHaveBeenCalledTimes(2);
         expect(getMany).toHaveBeenCalledTimes(1);
+        expect(response.body).toEqual([]);
 
         expect(response).toSatisfyApiSpec();
       });

--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -589,6 +589,67 @@ describe('job', function () {
       });
     });
 
+    describe('findJobsByCriteria', () => {
+      it('should get all jobs and return 200', async function () {
+        const filter = {
+          isCleaned: true,
+          resourceId: '1',
+          status: ['Pending'],
+          type: ['2'],
+          version: '3',
+        };
+        const jobModel = createJobDataForFind();
+        const jobEntity = jobModelToEntity(jobModel);
+        const select = jobRepositoryMocks.queryBuilder.select;
+        const from = jobRepositoryMocks.queryBuilder.from;
+        const where = jobRepositoryMocks.queryBuilder.where;
+        const andWhere = jobRepositoryMocks.queryBuilder.andWhere;
+        const getMany = jobRepositoryMocks.queryBuilder.getMany;
+        getMany.mockResolvedValue([jobEntity]);
+
+        const response = await requestSender.findJobs(filter);
+
+        expect(response.status).toBe(httpStatusCodes.OK);
+        expect(select).toHaveBeenCalledTimes(1);
+        expect(from).toHaveBeenCalledTimes(1);
+        expect(where).toHaveBeenCalledTimes(1);
+        expect(andWhere).toHaveBeenCalledTimes(2);
+        expect(getMany).toHaveBeenCalledTimes(1);
+
+        const jobs = response.body as unknown;
+        expect(jobs).toEqual([jobModel]);
+        expect(response).toSatisfyApiSpec();
+      });
+
+      it('should no jobs and return 200', async function () {
+        const filter = {
+          isCleaned: true,
+          resourceId: '1',
+          status: ['Pending'],
+          type: ['2'],
+          version: '3',
+        };
+
+        const select = jobRepositoryMocks.queryBuilder.select;
+        const from = jobRepositoryMocks.queryBuilder.from;
+        const where = jobRepositoryMocks.queryBuilder.where;
+        const andWhere = jobRepositoryMocks.queryBuilder.andWhere;
+        const getMany = jobRepositoryMocks.queryBuilder.getMany;
+        getMany.mockResolvedValue([]);
+
+        const response = await requestSender.findJobs(filter);
+
+        expect(response.status).toBe(httpStatusCodes.OK);
+        expect(select).toHaveBeenCalledTimes(1);
+        expect(from).toHaveBeenCalledTimes(1);
+        expect(where).toHaveBeenCalledTimes(1);
+        expect(andWhere).toHaveBeenCalledTimes(2);
+        expect(getMany).toHaveBeenCalledTimes(1);
+
+        expect(response).toSatisfyApiSpec();
+      });
+    });
+
     describe('getJob', () => {
       it('should get specific job and return 200', async function () {
         const jobModel = createJobDataForGetJob();

--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -594,8 +594,8 @@ describe('job', function () {
         const filter = {
           isCleaned: true,
           resourceId: '1',
-          status: ['Pending'],
-          type: ['2'],
+          statuses: ['Pending'],
+          types: ['2'],
           version: '3',
         };
         const jobModel = createJobDataForFind();
@@ -625,8 +625,8 @@ describe('job', function () {
         const filter = {
           isCleaned: true,
           resourceId: '1',
-          status: ['Pending'],
-          type: ['2'],
+          statuses: ['Pending'],
+          types: ['2'],
           version: '3',
         };
 


### PR DESCRIPTION
added new POST route to enable an array of jobTypes and Status types when querying Job table

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                   |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                      |
| Chore            | ✖                                                                       |

