### PR TITLE
feat: added option for releaseInactive to not raise task attempts (MAPCO-5466)

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -19,9 +19,9 @@ permissions:
 
 jobs:
   build_and_push_docker:
-      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v1
+      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v2
       secrets: inherit
   
   build_and_push_helm:
-      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v1
+      uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v2
       secrets: inherit

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,5 +4,5 @@ on: [pull_request]
 
 jobs:
   pull_request:
-    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@v1
+    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@v2
     secrets: inherit

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release_on_tag_push:
-    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@v1
+    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@v2
     secrets: inherit

--- a/config/default.json
+++ b/config/default.json
@@ -42,7 +42,7 @@
       "key": "",
       "cert": ""
     },
-    "database": "raster",
+    "database": "common",
     "schema": "public",
     "synchronize": false,
     "logging": false,

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -494,6 +494,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/taskIdList'
+      parameters:
+        - $ref: '#/components/parameters/raiseAttempts'
       responses:
         '200':
           description: OK
@@ -688,6 +690,13 @@ components:
       schema:
         type: string
         format: uuid
+    raiseAttempts:
+      in: query
+      name: raiseAttempts
+      description: whether or not to raise task attempts on release
+      required: false
+      schema:
+        type: boolean
   schemas:
     getJobsByCriteria:
       type: object

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -495,7 +495,7 @@ paths:
             schema:
               $ref: '#/components/schemas/taskIdList'
       parameters:
-        - $ref: '#/components/parameters/raiseAttempts'
+        - $ref: '#/components/parameters/shouldRaiseAttempts'
       responses:
         '200':
           description: OK
@@ -690,9 +690,9 @@ components:
       schema:
         type: string
         format: uuid
-    raiseAttempts:
+    shouldRaiseAttempts:
       in: query
-      name: raiseAttempts
+      name: shouldRaiseAttempts
       description: whether or not to raise task attempts on release
       required: false
       schema:

--- a/src/DAL/repositories/taskRepository.ts
+++ b/src/DAL/repositories/taskRepository.ts
@@ -141,7 +141,7 @@ export class TaskRepository extends GeneralRepository<TaskEntity> {
     return this.taskConvertor.entityToModel(entity);
   }
 
-  public async releaseInactiveTask(taskIds: string[], raiseAttempts: boolean): Promise<string[]> {
+  public async releaseInactiveTask(taskIds: string[], shouldRaiseAttempts: boolean): Promise<string[]> {
     const getJobStatusQuery = `
       SELECT task.id as "taskId", "jobId", task.status as "taskStatus", job.status as "jobStatus"
       FROM "Job" job, "Task" task
@@ -166,14 +166,14 @@ export class TaskRepository extends GeneralRepository<TaskEntity> {
     // Execute update query for Pending status
     if (pendingEntities.length > 0) {
       const pendingTaskIds = pendingEntities.map((entity) => entity.taskId);
-      await this.updateTaskStatus(pendingTaskIds, OperationStatus.PENDING, raiseAttempts);
+      await this.updateTaskStatus(pendingTaskIds, OperationStatus.PENDING, shouldRaiseAttempts);
       updatedIds.push(...pendingTaskIds);
     }
 
     // Execute update query for Aborted status
     if (abortedEntities.length > 0) {
       const abortedTaskIds = abortedEntities.map((entity) => entity.taskId);
-      await this.updateTaskStatus(abortedTaskIds, OperationStatus.ABORTED, raiseAttempts);
+      await this.updateTaskStatus(abortedTaskIds, OperationStatus.ABORTED, shouldRaiseAttempts);
       updatedIds.push(...abortedTaskIds);
     }
 
@@ -306,10 +306,10 @@ export class TaskRepository extends GeneralRepository<TaskEntity> {
     }
   }
 
-  private async updateTaskStatus(taskIds: string[], newStatus: OperationStatus, raiseAttempts: boolean): Promise<void> {
+  private async updateTaskStatus(taskIds: string[], newStatus: OperationStatus, shouldRaiseAttempts: boolean): Promise<void> {
     await this.createQueryBuilder()
       .update()
-      .set({ status: newStatus, attempts: () => (raiseAttempts ? 'attempts + 1' : 'attempts') })
+      .set({ status: newStatus, attempts: () => (shouldRaiseAttempts ? 'attempts + 1' : 'attempts') })
       .where({ id: In(taskIds) })
       .returning('id')
       .updateEntity(true)

--- a/src/common/dataModels/tasks.ts
+++ b/src/common/dataModels/tasks.ts
@@ -52,7 +52,7 @@ export interface IFindInactiveTasksRequest {
 }
 
 export interface IReleaseInactiveQuery {
-  raiseAttempts?: boolean;
+  shouldRaiseAttempts?: boolean;
 }
 
 //responses

--- a/src/common/dataModels/tasks.ts
+++ b/src/common/dataModels/tasks.ts
@@ -51,6 +51,10 @@ export interface IFindInactiveTasksRequest {
   ignoreTypes?: ITaskType[];
 }
 
+export interface IReleaseInactiveQuery {
+  raiseAttempts?: boolean;
+}
+
 //responses
 export interface IGetTaskResponse {
   id: string;

--- a/src/common/dataModels/tasks.ts
+++ b/src/common/dataModels/tasks.ts
@@ -51,7 +51,7 @@ export interface IFindInactiveTasksRequest {
   ignoreTypes?: ITaskType[];
 }
 
-export interface IReleaseInactiveQuery {
+export interface IReleaseInactiveQueryParams {
   shouldRaiseAttempts?: boolean;
 }
 

--- a/src/taskManagement/controllers/taskManagementController.ts
+++ b/src/taskManagement/controllers/taskManagementController.ts
@@ -5,13 +5,13 @@ import { ErrorResponse } from '@map-colonies/error-express-handler';
 import httpStatus from 'http-status-codes';
 import { injectable, inject } from 'tsyringe';
 import { ResponseCodes, SERVICES } from '../../common/constants';
-import { IFindInactiveTasksRequest, IGetTaskResponse, IRetrieveAndStartRequest } from '../../common/dataModels/tasks';
+import { IFindInactiveTasksRequest, IGetTaskResponse, IReleaseInactiveQuery, IRetrieveAndStartRequest } from '../../common/dataModels/tasks';
 import { DefaultResponse } from '../../common/interfaces';
 import { TaskManagementManager } from '../models/taskManagementManger';
 import { IJobsParams, IJobsQuery } from '../../common/dataModels/jobs';
 
 type RetrieveAndStartHandler = RequestHandler<IRetrieveAndStartRequest, IGetTaskResponse | ErrorResponse>;
-type ReleaseInactiveTasksHandler = RequestHandler<undefined, string[], string[]>;
+type ReleaseInactiveTasksHandler = RequestHandler<undefined, string[], string[], IReleaseInactiveQuery>;
 type FindInactiveTasksHandler = RequestHandler<undefined, string[], IFindInactiveTasksRequest>;
 type UpdateExpiredStatusHandler = RequestHandler<undefined, DefaultResponse>;
 type AbortHandler = RequestHandler<IJobsParams, DefaultResponse, undefined, IJobsQuery>;
@@ -38,7 +38,7 @@ export class TaskManagementController {
 
   public releaseInactive: ReleaseInactiveTasksHandler = async (req, res, next) => {
     try {
-      const releasedIds = await this.manager.releaseInactive(req.body);
+      const releasedIds = await this.manager.releaseInactive(req.body, req.query.raiseAttempts);
       return res.status(httpStatus.OK).json(releasedIds);
     } catch (err) {
       return next(err);

--- a/src/taskManagement/controllers/taskManagementController.ts
+++ b/src/taskManagement/controllers/taskManagementController.ts
@@ -38,7 +38,7 @@ export class TaskManagementController {
 
   public releaseInactive: ReleaseInactiveTasksHandler = async (req, res, next) => {
     try {
-      const releasedIds = await this.manager.releaseInactive(req.body, req.query.raiseAttempts);
+      const releasedIds = await this.manager.releaseInactive(req.body, req.query.shouldRaiseAttempts);
       return res.status(httpStatus.OK).json(releasedIds);
     } catch (err) {
       return next(err);

--- a/src/taskManagement/controllers/taskManagementController.ts
+++ b/src/taskManagement/controllers/taskManagementController.ts
@@ -5,13 +5,13 @@ import { ErrorResponse } from '@map-colonies/error-express-handler';
 import httpStatus from 'http-status-codes';
 import { injectable, inject } from 'tsyringe';
 import { ResponseCodes, SERVICES } from '../../common/constants';
-import { IFindInactiveTasksRequest, IGetTaskResponse, IReleaseInactiveQuery, IRetrieveAndStartRequest } from '../../common/dataModels/tasks';
+import { IFindInactiveTasksRequest, IGetTaskResponse, IReleaseInactiveQueryParams, IRetrieveAndStartRequest } from '../../common/dataModels/tasks';
 import { DefaultResponse } from '../../common/interfaces';
 import { TaskManagementManager } from '../models/taskManagementManger';
 import { IJobsParams, IJobsQuery } from '../../common/dataModels/jobs';
 
 type RetrieveAndStartHandler = RequestHandler<IRetrieveAndStartRequest, IGetTaskResponse | ErrorResponse>;
-type ReleaseInactiveTasksHandler = RequestHandler<undefined, string[], string[], IReleaseInactiveQuery>;
+type ReleaseInactiveTasksHandler = RequestHandler<undefined, string[], string[], IReleaseInactiveQueryParams>;
 type FindInactiveTasksHandler = RequestHandler<undefined, string[], IFindInactiveTasksRequest>;
 type UpdateExpiredStatusHandler = RequestHandler<undefined, DefaultResponse>;
 type AbortHandler = RequestHandler<IJobsParams, DefaultResponse, undefined, IJobsQuery>;

--- a/src/taskManagement/models/taskManagementManger.ts
+++ b/src/taskManagement/models/taskManagementManger.ts
@@ -23,10 +23,10 @@ export class TaskManagementManager {
   ) {}
 
   @withSpanAsyncV4
-  public async releaseInactive(tasks: string[], raiseAttempts?: boolean): Promise<string[]> {
+  public async releaseInactive(tasks: string[], shouldRaiseAttempts?: boolean): Promise<string[]> {
     const repo = await this.getTaskRepository();
     this.logger.info(`trying to release dead tasks: ${tasks.join(',')}`);
-    const releasedTasks = await repo.releaseInactiveTask(tasks, raiseAttempts ?? true);
+    const releasedTasks = await repo.releaseInactiveTask(tasks, shouldRaiseAttempts ?? true);
     this.logger.info(`released dead tasks: ${releasedTasks.join(',')}`);
     return releasedTasks;
   }

--- a/src/taskManagement/models/taskManagementManger.ts
+++ b/src/taskManagement/models/taskManagementManger.ts
@@ -23,10 +23,10 @@ export class TaskManagementManager {
   ) {}
 
   @withSpanAsyncV4
-  public async releaseInactive(tasks: string[]): Promise<string[]> {
+  public async releaseInactive(tasks: string[], raiseAttempts?: boolean): Promise<string[]> {
     const repo = await this.getTaskRepository();
     this.logger.info(`trying to release dead tasks: ${tasks.join(',')}`);
-    const releasedTasks = await repo.releaseInactiveTask(tasks);
+    const releasedTasks = await repo.releaseInactiveTask(tasks, raiseAttempts ?? true);
     this.logger.info(`released dead tasks: ${releasedTasks.join(',')}`);
     return releasedTasks;
   }


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->
Added this feature to handle task liberator's updateTime release better. Task liberator releases "lost" tasks that were pulled but never had a heartbeat. In the current version, Job manager would release the task and raise the task's attempts by one. This way, attempts are raised without a worker working on the task, and by the time a worker actually works on that task, the attempts reach its limits. This PR adds an option through an optional query param to release the task without raising the number of attempts. If the "shouldRaiseAttempts" param is not provided, the default behavior will increase the attempts. This way it doesn't break anything and past requests should still work. A following task liberator PR will come.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

A video of a local test of the expected behaviour:
[job-manager.webm](https://github.com/user-attachments/assets/f4d3e499-1df0-4fe4-b377-c7f87755f36b)